### PR TITLE
parsimonious 0.10.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-    - regex
+    - regex >=2022.3.15
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,27 +10,30 @@ source:
   sha256: 8281600da180ec8ae35427a4ab4f7b82bfec1e3d1e52f80cb60ea82b9512501c
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
     - regex
 
 test:
   imports:
     - parsimonious
   requires:
+    - pip
     - pytest
   source_files:
     - parsimonious/tests
   commands:
-    - pytest parsimonious/tests
+    - pip check
+    - pytest parsimonious/tests --ignore=parsimonious/tests/test_benchmarks.py
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,11 +29,9 @@ test:
   requires:
     - pip
     - pytest
-  source_files:
-    - parsimonious/tests
   commands:
     - pip check
-    - pytest parsimonious/tests --ignore=parsimonious/tests/test_benchmarks.py
+    - pytest --pyargs parsimonious -v --ignore=tests/test_benchmarks.py
 
 
 about:


### PR DESCRIPTION
parsimonious 0.10.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3931]
- dev_url: https://github.com/erikrose/parsimonious/tree/0.10.0
- conda-forge: https://github.com/conda-forge/parsimonious-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/parsimonious

### Explanation of changes:

- bump version, skip benchmark tests, add abs for SF

[PKG-3931]: https://anaconda.atlassian.net/browse/PKG-3931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ